### PR TITLE
- added 'add_show' to `base.html`

### DIFF
--- a/nstv/models.py
+++ b/nstv/models.py
@@ -13,7 +13,6 @@ shows = Table(
     Column("title", String, unique=True),
     Column("start_date", Date),
     Column("end_date", Date),
-    Column("slug", String, unique=True),
 )
 
 episodes = Table(
@@ -51,9 +50,6 @@ class Show(Base):
     title = Column(String, unique=True)
     start_date = Column(Date, default=None)
     end_date = Column(Date, default=None)
-    slug = Column(String, unique=True)
-
-    # show.slug is the show's title with all punctuation & non-alphanumeric chars removed
 
     episodes = relationship("Episode")
 

--- a/nstv_fe/nstv_fe/forms.py
+++ b/nstv_fe/nstv_fe/forms.py
@@ -3,7 +3,7 @@ from django import forms
 title_choices = (
     (1, 'Beat Bobby Flay'), (2, 'Chopped'), (3, 'House Hunters'),
     (4, 'House Hunters International'), (5, 'Escape to the Chateau'),
-    (6, 'Chopped Junior'), (7, 'Big Time Bake')
+    (6, 'Chopped Junior'), (7, 'Big Time Bake'), (8, 'Kotaro Lives Alone'),
 )
 
 

--- a/nstv_fe/nstv_fe/views.py
+++ b/nstv_fe/nstv_fe/views.py
@@ -26,6 +26,7 @@ def index(request):
             try:
                 show = Show.objects.get(title=show_title)
             except Show.DoesNotExist:
+                print(f"Show {show_title} not found.  Adding to database.")
                 return redirect("/add_show")
             print(f"Downloading {show.title} S{season_number} E{episode_number}..")
             try:

--- a/nstv_fe/templates/base.html
+++ b/nstv_fe/templates/base.html
@@ -31,6 +31,7 @@ th {
         <ul>
             <li><a href="/">Home</a></li>
             <li><a href="/shows_index/">Show Index</a></li>
+            <li><a href="/add_show/">Add Show</a></li>
         </ul>
         {% endblock %}
     </div>

--- a/plexController/main.py
+++ b/plexController/main.py
@@ -1,0 +1,24 @@
+from plexapi.myplex import MyPlexAccount
+import os
+import django
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'nstv_fe.nstv_fe.settings')
+django.setup()
+from django.shortcuts import render, redirect
+from nstv_fe.nstv_fe.forms import DownloadForm, AddShowForm
+from nstv_fe.nstv_fe.models import Show, Episode
+from nstv_fe.nstv_fe.tables import ShowTable
+
+account = MyPlexAccount('nicktucker4@gmail.com', os.getenv('PLEX_API_KEY'))
+plex = account.resource(os.getenv('PLEX_SERVER')).connect()  # returns a PlexServer instance
+
+plexTvShows = plex.library.section('TV Shows')
+for show in plexTvShows.search():
+    print(show.title)
+    showObject = Show.objects.all().filter(title=show.title)
+    if showObject:
+        print('show already exists')
+    else:
+        print('show does not exist')
+        showObject = Show(title=show.title)
+        showObject.save()
+        print('show added to database')


### PR DESCRIPTION
- remove slug columns
- add plexController/main.py, which takes shows existing on my plex account and adds them to the Django DB.  The lookup/index page should then use that same django DB for the shows listed instead of the hardcoded list.
- add print statement to `views.py`