### PR TITLE
- add 'TV > Foreign' to acceptable categories

### DIFF
--- a/nstv/download.py
+++ b/nstv/download.py
@@ -22,7 +22,11 @@ SHOW_TITLE_REPLACEMENTS = {
 
 class SearchResult:
     def __init__(self, result_table):
-        self.title = result_table.find("a", class_="releases_title").text.strip()
+        self.title = result_table.find("a", class_="releases_title")
+        if self.title:
+            self.title = self.title.text.strip()
+        else:
+            return
         self.category = result_table.find(
             "a", class_="releases_category_text"
         ).text.strip()
@@ -164,14 +168,14 @@ class NZBGeek:
 
         soup = BeautifulSoup(r.content, "html.parser")
         results = soup.find_all("table", class_="releases")
-        results = [SearchResult(i) for i in results]
+        results = [SearchResult(i) for i in results if i.find("a", class_="releases_title")]
         if hd:
-            results = [i for i in results if i.category in ["TV > HD", 'TV > Anime']]
+            results = [i for i in results if i.category in ["TV > HD", 'TV > Anime', 'TV > Foreign']]
             if not len(results):
                 print("No HD results found. Searching for SD results.")
                 results = soup.find_all("table", class_="releases")
-                results = [SearchResult(i) for i in results]
-                results = [i for i in results if i.category in ["TV > SD", 'TV > Anime']]
+                results = [SearchResult(i) for i in results if i.find("a", class_="releases_title")]
+                results = [i for i in results if i.category in ["TV > SD", 'TV > Anime', 'TV > Foreign']]
         # sort results by grabs
 
         if not len(results):

--- a/nstv/get_info_from_tvdb/main.py
+++ b/nstv/get_info_from_tvdb/main.py
@@ -17,7 +17,6 @@ def find_tvdb_record_for_series(tvdb_api, series_name):
     if series_name in TVDB_ALIAS:
         series_name = TVDB_ALIAS[series_name]
     items = tvdb_api.search(query=series_name, type='series', language='eng')
-    print(items)
     for i in items:
         translations = i.get('translations')
         englishTranslation = translations['eng']
@@ -79,4 +78,4 @@ def main(show_title):
 
 
 if __name__ == '__main__':
-    main("Neon Genesis Evangelion")
+    main("The French Chef")

--- a/nstv/plexController/add_episodes_to_show.py
+++ b/nstv/plexController/add_episodes_to_show.py
@@ -32,6 +32,8 @@ def add_existing_episodes_for_plex_show(plex_show):
     for plex_episode in plex_show.episodes():
         if plex_episode.title:
             django_episode = django_episodes.filter(title=plex_episode.title).first()
+            if not django_episode:
+                django_episode = django_episodes.filter(title=plex_episode.title.replace('.', '')).first()
             if django_episode:
                 #print('episode already exists')
                 # if the show is on plex, it's on disk, so we can update that if necessary


### PR DESCRIPTION
- remove `print` in `get_info_from_tvdb/main.py`
- remove '.' from a plex episode title if there's no match found for it and search again - sometimes 'Chef 1 vs. Chef 2' titles were getting duplicated because of the '.' difference between nzbgeek and tvdb