### PR TITLE
- different NZBs can have the same title, which was causing the NZBDo…

### DIFF
--- a/nstv/download.py
+++ b/nstv/download.py
@@ -309,7 +309,10 @@ class NZBGeek:
         else:
             print(f"Found {len(results)} results.")
 
+        result_counter = 0
         for result in tqdm(results):
+            result_counter += 1
+            result.title = f"{result.title}_{result_counter}"
             print(f"Downloading {result.title} from {result.download_url}")
             r = self.session.get(result.download_url)
             with open(f"{Path.home()}\\Downloads\\{result.title}.nzb", "wb") as f:


### PR DESCRIPTION
…wnload logic to incorrectly report that a download failed if the first download of the NZB failed but the second succeeded. this was leading to duplicate files, so now we append an index to the result's title.